### PR TITLE
Add ChannelIndex and Unit to ChannelView and Group converter

### DIFF
--- a/neo/converter.py
+++ b/neo/converter.py
@@ -1,0 +1,90 @@
+from neo import Group, Unit, ChannelView, SpikeTrain
+from neo.core.basesignal import BaseSignal
+
+
+def _convert_unit(unit):
+    group_unit = Group(unit.spiketrains,
+                       name=unit.name,
+                       file_origin=unit.file_origin,
+                       description=unit.description,
+                       allowed_types=[SpikeTrain],
+                       **unit.annotations)
+    # clean up references
+    for st in unit.spiketrains:
+        delattr(st, 'unit')
+    return group_unit
+
+
+def _convert_channel_index(channel_index):
+    # convert child objects
+    new_child_objects = []
+    for child_obj in channel_index.children:
+        if isinstance(child_obj, Unit):
+            new_unit = _convert_unit(child_obj)
+            new_child_objects.append(new_unit)
+        elif isinstance(child_obj, BaseSignal):
+            # always generate view, as this might provide specific info regarding the object
+            new_view = ChannelView(child_obj, channel_index.index,
+                                   name=channel_index.name,
+                                   description=channel_index.description,
+                                   file_origin=channel_index.file_origin,
+                                   **channel_index.annotations)
+            new_view.array_annotate(channel_ids=channel_index.channel_ids,
+                                    channel_names=channel_index.channel_names)
+
+            # separate dimenions of coordinates into different 1D array_annotations
+            if channel_index.coordinates.shape:
+                if len(channel_index.coordinates.shape) == 1:
+                    new_view.array_annotate(coordinates=channel_index.coordinates)
+                elif len(channel_index.coordinates.shape) == 2:
+                    for dim in range(channel_index.coordinates.shape[1]):
+                        new_view.array_annotate(
+                            **{f'coordinates_dim{dim}': channel_index.coordinates[:, dim]})
+                else:
+                    raise ValueError(f'Incompatible channel index coordinates with wrong '
+                                     f'dimensions: Provided coordinates have shape '
+                                     f'{channel_index.coordinates.shape}.')
+
+            # clean up references
+            delattr(child_obj, 'channel_index')
+
+            new_child_objects.append(new_view)
+
+    new_channel_group = Group(new_child_objects,
+                              name=channel_index.name,
+                              file_origin=channel_index.file_origin,
+                              description=channel_index.description,
+                              **channel_index.annotations)
+
+    return new_channel_group
+
+
+def convert_channelindex_to_view_group(block):
+    """
+    Convert deprecated ChannelIndex and Unit objects to ChannelView and Group objects
+
+    This conversion is preserving all information stored as attributes and (array) annotations.
+    The conversion is done in-place.
+    Each ChannelIndex is represented as a Group. Linked Unit objects are represented as child Group
+    (subgroup) objects. Linked data objects (neo.AnalogSignal, neo.IrregularlySampledSignal) are
+    represented by a View object linking to the original data object.
+    Attributes are as far as possible conserved by the conversion of objects. `channel_ids`,
+    `channel_names` and `coordinates` are converted to array_annotations.
+
+    :param block: neo.Block structure to be converted
+    :return: block: updated neo.Block structure
+    """
+    for channel_index in block.channel_indexes:
+        new_channel_group = _convert_channel_index(channel_index)
+        block.groups.append(new_channel_group)
+
+    # clean up references
+    delattr(block, 'channel_indexes')
+
+    # this is a hack to clean up ImageSequence objects that are not properly linked to
+    # ChannelIndex objects, see also Issue #878
+    for seg in block.segments:
+        for imgseq in seg.imagesequences:
+            delattr(imgseq, 'channel_index')
+
+    return block

--- a/neo/core/view.py
+++ b/neo/core/view.py
@@ -57,8 +57,9 @@ class ChannelView(BaseNeo):
             if self.index.size != self.obj.shape[-1]:
                 raise ValueError("index size does not match number of channels in signal")
             self.index, = np.nonzero(self.index)
-        elif self.index.dtype != np.integer:
-            raise ValueError("index must be a boolean or integer list or array")
+        # allow any type of integer representation
+        elif self.index.dtype.char not in np.typecodes['AllInteger']:
+            raise ValueError("index must be of a list or array of data type boolean or integer")
 
         if not hasattr(self, 'array_annotations') or not self.array_annotations:
             self.array_annotations = ArrayDict(self._get_arr_ann_length())

--- a/neo/test/coretest/test_block.py
+++ b/neo/test/coretest/test_block.py
@@ -243,8 +243,8 @@ class TestBlock(unittest.TestCase):
         blk1a.segments.append(self.segs2[0])
         blk1a.merge(self.blk2)
 
-        segs1a = clone_object(self.blk1).segments
-        chxs1a = clone_object(self.chxs1)
+        segs1a = deepcopy(self.blk1.segments)
+        chxs1a = deepcopy(self.chxs1)
 
         assert_same_sub_schema(chxs1a + self.chxs2,
                                blk1a.channel_indexes)
@@ -252,8 +252,8 @@ class TestBlock(unittest.TestCase):
                                blk1a.segments)
 
     def test__children(self):
-        segs1a = clone_object(self.blk1).segments
-        chxs1a = clone_object(self.chxs1)
+        segs1a = deepcopy(self.blk1.segments)
+        chxs1a = deepcopy(self.chxs1)
 
         self.assertEqual(self.blk1._container_child_objects,
                          ('Segment', 'ChannelIndex', 'Group'))

--- a/neo/test/coretest/test_generate_datasets.py
+++ b/neo/test/coretest/test_generate_datasets.py
@@ -592,7 +592,7 @@ class Test__generate_datasets(unittest.TestCase):
         resattr = get_fake_values(cls, annotate=False, seed=0)
         if seed is not None:
             for name, value in resattr.items():
-                if name in ['channel_names', 'channel_indexes', 'channel_index', 'coordinates']:
+                if name in ['channel_names', 'channel_indexes', 'index', 'coordinates']:
                     continue
                 try:
                     try:

--- a/neo/test/coretest/test_generate_datasets.py
+++ b/neo/test/coretest/test_generate_datasets.py
@@ -592,7 +592,7 @@ class Test__generate_datasets(unittest.TestCase):
         resattr = get_fake_values(cls, annotate=False, seed=0)
         if seed is not None:
             for name, value in resattr.items():
-                if name in ['channel_names', 'channel_indexes', 'index', 'coordinates']:
+                if name in ['channel_names', 'channel_ids', 'index', 'coordinates']:
                     continue
                 try:
                     try:

--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -206,12 +206,14 @@ def get_fake_value(name, datatype, dim=0, dtype='float', seed=None, units=None, 
         data = np.array(0.0)
     elif name == 't_stop':
         data = np.array(1.0)
-    elif n and name == 'channel_indexes':
+    elif n and name in ['channel_indexes', 'channel_ids']:
         data = np.arange(n)
+    elif n and name == 'coordinates':
+        data = np.arange(0, 2*n).reshape((n, 2))
     elif n and name == 'channel_names':
         data = np.array(["ch%d" % i for i in range(n)])
     elif n and name == 'index':  # ChannelIndex.index
-        data = np.random.randint(0, n, np.random.randint(n)+1)
+        data = np.random.randint(0, n, n)
     elif n and obj == 'AnalogSignal':
         if name == 'signal':
             size = []

--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -210,6 +210,8 @@ def get_fake_value(name, datatype, dim=0, dtype='float', seed=None, units=None, 
         data = np.arange(n)
     elif n and name == 'channel_names':
         data = np.array(["ch%d" % i for i in range(n)])
+    elif n and name == 'index':  # ChannelIndex.index
+        data = np.random.randint(0, n, np.random.randint(n)+1)
     elif n and obj == 'AnalogSignal':
         if name == 'signal':
             size = []
@@ -274,8 +276,7 @@ def get_fake_values(cls, annotate=True, seed=None, n=None):
     If annotate is True (default), also add annotations to the values.
     """
 
-    if hasattr(cls,
-               'lower'):  # is this a test that cls is a string? better to use isinstance(cls,
+    if hasattr(cls, 'lower'):  # is this a test that cls is a string? better to use isinstance(cls,
         # basestring), no?
         cls = class_by_name[cls]
     # iseed is needed below for generation of array annotations

--- a/neo/test/test_converter.py
+++ b/neo/test/test_converter.py
@@ -1,0 +1,94 @@
+"""
+Tests of the neo.conversion module
+"""
+
+import unittest
+import copy
+import numpy as np
+
+from neo.io.proxyobjects import (AnalogSignalProxy, SpikeTrainProxy,
+                EventProxy, EpochProxy)
+
+from neo.core import (Epoch, Event, SpikeTrain)
+from neo.core.basesignal import BaseSignal
+
+from neo.test.tools import (assert_arrays_equal, assert_same_attributes)
+from neo.test.generate_datasets import fake_neo
+from neo.converter import convert_channelindex_to_view_group
+
+class ConversionTest(unittest.TestCase):
+    def setUp(self):
+        block = fake_neo(n=3)
+        self.old_block = copy.deepcopy(block)
+        self.new_block = convert_channelindex_to_view_group(block)
+
+    def test_no_deprecated_attributes(self):
+        self.assertFalse(hasattr(self.new_block, 'channel_indexes'))
+        # collecting data objects
+        objs = []
+        for seg in self.new_block.segments:
+            objs.extend(seg.analogsignals)
+            objs.extend(seg.irregularlysampledsignals)
+            objs.extend(seg.events)
+            objs.extend(seg.epochs)
+            objs.extend(seg.spiketrains)
+            objs.extend(seg.imagesequences)
+
+        for obj in objs:
+            if isinstance(obj, BaseSignal):
+                self.assertFalse(hasattr(obj, 'channel_index'))
+            elif isinstance(obj, SpikeTrain):
+                self.assertFalse(hasattr(obj, 'unit'))
+            elif isinstance(obj, (Event, Epoch)):
+                pass
+            else:
+                raise TypeError(f'Unexpected data type object {type(obj)}')
+
+    def test_block_conversion(self):
+        # verify that all previous data is present in new structure
+        groups = self.new_block.groups
+        for channel_index in self.old_block.channel_indexes:
+            # check existence of objects and attributes
+            self.assertIn(channel_index.name, [g.name for g in groups])
+            group = groups[[g.name for g in groups].index(channel_index.name)]
+
+            # comparing group attributes to channel_index attributes
+            assert_same_attributes(group, channel_index)
+            self.assertDictEqual(channel_index.annotations, group.annotations)
+
+            # comparing views and their attributes
+            view_names = np.asarray([v.name for v in group.channelviews])
+            matching_views = np.asarray(group.channelviews)[view_names == channel_index.name]
+            for view in matching_views:
+                self.assertIn('channel_ids', view.array_annotations)
+                self.assertIn('channel_names', view.array_annotations)
+                self.assertIn('coordinates_dim0', view.array_annotations)
+                self.assertIn('coordinates_dim1', view.array_annotations)
+
+                # check content of attributes
+                assert_arrays_equal(channel_index.index, view.index)
+                assert_arrays_equal(channel_index.channel_ids, view.array_annotations['channel_ids'])
+                assert_arrays_equal(channel_index.channel_names,
+                                    view.array_annotations['channel_names'])
+                view_coordinates = np.vstack((view.array_annotations['coordinates_dim0'],
+                                              view.array_annotations['coordinates_dim1'])).T
+                # readd unit lost during stacking of arrays
+                units = view.array_annotations['coordinates_dim0'].units
+                view_coordinates = view_coordinates.magnitude * units
+                assert_arrays_equal(channel_index.coordinates, view_coordinates)
+                self.assertDictEqual(channel_index.annotations, view.annotations)
+
+            # check linking between objects
+            self.assertEqual(len(channel_index.data_children), len(matching_views))
+
+            # check linking between objects
+            for child in channel_index.data_children:
+                # comparing names instead of objects as attributes differ
+                self.assertIn(child.name, [v.obj.name for v in matching_views])
+            group_names = np.asarray([g.name for g in group.groups])
+            for unit in channel_index.units:
+                self.assertIn(unit.name, group_names)
+
+            matching_groups = np.asarray(group.groups)[group_names == unit.name]
+            self.assertEqual(len(channel_index.units), len(matching_groups))
+


### PR DESCRIPTION
This PR adds a reference conversion of ChannelIndex and Unit objects to View and Group objects.

The conversion allows the automatic update of neo structure based on the deprecated ChannelIndex and Unit objects by replacing them with ChannelView and Group objects.

The conversion preserved information and is done in-place.
 Each ChannelIndex is represented as a Group. Linked Unit objects are represented as child Group  (subgroup) objects. Linked data objects (neo.AnalogSignal, neo.IrregularlySampledSignal) are  represented by a View object linking to the original data object. Attributes are as far as possible conserved by the conversion of objects. `channel_ids`,  `channel_names` and `coordinates` are converted to array_annotations.

Furthermore this PR improves the generation of ChannelIndexes for neo unittest purposes and relaxes the dtype of the `Viewx.index` attribute from `np.integer` to any integer type to allow for easy conversion of the `ChannelIndex.index` attribute.